### PR TITLE
Update windows.buildinfo.json

### DIFF
--- a/packages/nssm/windows.buildinfo.json
+++ b/packages/nssm/windows.buildinfo.json
@@ -2,7 +2,7 @@
   "sources": {
     "nssm": {
       "kind": "url",
-      "url": "http://nssm.cc/ci/nssm-2.24-101-g897c7ad.zip",
+      "url": "https://s3.amazonaws.com/downloads.mesosphere.io/nssm/nssm-2.24-101-g897c7ad.zip",
       "sha1": "ca2f6782a05af85facf9b620e047b01271edd11d"
     }
   }


### PR DESCRIPTION
we are hosting the nssm file on our own. this helps to avoid using unstable external sites