### PR TITLE
Force file encoding to UTF-8

### DIFF
--- a/packages/winpanda/extra/src/winpanda/cfgm/cfgm.py
+++ b/packages/winpanda/extra/src/winpanda/cfgm/cfgm.py
@@ -207,7 +207,7 @@ class PkgConfManager:
                       f' {src_fpath}: Rendered content: {rendered_str}')
 
             dst_fpath = tmp_dpath.joinpath(dst_fname)
-            dst_fpath.write_text(rendered_str)
+            dst_fpath.write_text(rendered_str, encoding='utf-8')
             LOG.debug(f'{self.msg_src}: Process configuration file:'
                       f' {src_fpath}: Save: {dst_fpath}')
         except (FileNotFoundError, j2.TemplateNotFound) as e:


### PR DESCRIPTION
<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

Use UTF-8 rather than win1252 for created files:
```
    default: VERBOSE: Running Winpanda.py start ...
    default: Traceback (most recent call last):
    default:   File "C:\d2iq\dcos\winpanda\cfgm\cfgm.py", line 109, in setup_conf
    default:     context=pkg_context
    default:   File "C:\d2iq\dcos\winpanda\cfgm\cfgm.py", line 163, in _process_pkgconf_srcdir
    default:     context=context
    default:   File "C:\d2iq\dcos\winpanda\cfgm\cfgm.py", line 210, in _process_pkgconf_srcfile
    default:     dst_fpath.write_text(rendered_str)
    default:   File "C:\Python36\lib\pathlib.py", line 1194, in write_text
    default:     return f.write(data)
    default:   File "C:\Python36\lib\encodings\cp1252.py", line 19, in encode
    default:     return codecs.charmap_encode(input,self.errors,encoding_table)[0]
    default: UnicodeEncodeError: 'charmap' codec can't encode character '\ufeff' in position 0: character maps to <undefined>
    default: During handling of the above exception, another exception occurred:
    default: Traceback (most recent call last):
    default:   File "C:\d2iq\dcos\winpanda\core\command.py", line 181, in _handle_pkg_cfg_setup
    default:     package.cfg_manager.setup_conf()
    default:   File "C:\d2iq\dcos\winpanda\cfgm\cfgm.py", line 115, in setup_conf
    default:     raise cfgm_exc.PkgConfManagerError(err_msg)
    default: cfgm.exceptions.PkgConfManagerError: Process configuration sources: UnicodeEncodeError: 'charmap' codec can't encode character '\ufeff' in position 0: character maps to <undefined>
    default: The above exception was the direct cause of the following exception:
    default: Traceback (most recent call last):
    default:   File "C:\d2iq\dcos\winpanda\bin\winpanda.py", line 117, in main
    default:     DCOSInstallationManager().command_.execute()
    default:   File "C:\d2iq\dcos\winpanda\core\command.py", line 157, in execute
    default:     self._handle_pkg_cfg_setup(package)
    default:   File "C:\d2iq\dcos\winpanda\core\command.py", line 188, in _handle_pkg_cfg_setup
    default:     raise cr_exc.SetupCommandError(err_msg) from e
    default: core.exceptions.SetupCommandError: Execute: bootstrap: Setup configuration:PkgConfManagerError: Process configuration sources: UnicodeEncodeError: 'charmap' codec can't encode character '\ufeff' in position 0: character maps to <undefined>
```

## Corresponding DC/OS tickets (required)

  - [DCOS-ID](https://jira.mesosphere.com/browse/DCOS-<number>) JIRA title / short description.


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [DCOS-ID](https://jira.mesosphere.com/browse/DCOS-<number>) JIRA title / short description.


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
  

<!--

## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require approvals from any two users on the most recent commit. Any commits added to the pull request after approval will invalidate the approvals.

Reviewers should be:

* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. 
Once a PR has **2 approvals**, **no red reviews**, and **all tests are green** it will be included in the next Merge Train.

-->
